### PR TITLE
Correct return type for Redis.quit()

### DIFF
--- a/test/lib/mock-ioredis.ts
+++ b/test/lib/mock-ioredis.ts
@@ -45,7 +45,7 @@ export class MockIORedis extends IORedis {
     this.connected = false
   }
 
-  quit(): Promise<string> {
+  quit(): Promise<"OK"> {
     this.disconnect()
     return Promise.resolve("OK")
   }


### PR DESCRIPTION
Fixes:

```
test/lib/mock-ioredis.ts:48:3 - error TS2416: Property 'quit' in type 'MockIORedis' is not assignable to the same property in base type 'Redis'.
  Type '() => Promise<string>' is not assignable to type '{ (callback: Callback<"OK">): void; (): Promise<"OK">; }'.
    Type 'Promise<string>' is not assignable to type 'Promise<"OK">'.
      Type 'string' is not assignable to type '"OK"'.

48   quit(): Promise<string> {
     ~~~~
```
